### PR TITLE
Update driver version in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     hci = {
       source = "hypertec-cloud/hci"
-      version = "1.6.0"
+      version = "1.0.0"
     }
   }
 }


### PR DESCRIPTION
### Description

Update the readme driver version from 1.6.0 (previous cloud-ca/cloudca driver) to 1.0.0 (hypertec-cloud/hci).
